### PR TITLE
Lc 66 auth UI into reusable components

### DIFF
--- a/frontend/labs-chat/src/app/components/auth/ConfirmResetPasswordForm.tsx
+++ b/frontend/labs-chat/src/app/components/auth/ConfirmResetPasswordForm.tsx
@@ -1,15 +1,11 @@
 "use client";
-import {
-  AtSymbolIcon,
-  ExclamationCircleIcon,
-  KeyIcon,
-} from "@heroicons/react/24/outline";
+import { AtSymbolIcon, KeyIcon } from "@heroicons/react/24/outline";
 import { useFormState } from "react-dom";
 import { handleConfirmResetPassword } from "@helpers/cognito-actions";
 import FormConfirmButton from "@components/FormConfirmButton";
 import FormWrapper from "@components/auth/ui/FormWrapper";
 import FormInput from "@components/auth/ui/FormInput";
-import FormErrorMessage from "./ui/FormErrorMessage";
+import FormErrorMessage from "@components/auth/ui/FormErrorMessage";
 
 export default function ConfirmResetPasswordForm() {
   const [errorMessage, dispatch] = useFormState(

--- a/frontend/labs-chat/src/app/components/auth/ConfirmResetPasswordForm.tsx
+++ b/frontend/labs-chat/src/app/components/auth/ConfirmResetPasswordForm.tsx
@@ -3,9 +3,7 @@ import { AtSymbolIcon, KeyIcon } from "@heroicons/react/24/outline";
 import { useFormState } from "react-dom";
 import { handleConfirmResetPassword } from "@helpers/cognito-actions";
 import FormConfirmButton from "@components/FormConfirmButton";
-import FormWrapper from "@components/auth/ui/FormWrapper";
-import FormInput from "@components/auth/ui/FormInput";
-import FormErrorMessage from "@components/auth/ui/FormErrorMessage";
+import { FormWrapper, FormInput, FormErrorMessage } from "@components/auth/ui";
 
 export default function ConfirmResetPasswordForm() {
   const [errorMessage, dispatch] = useFormState(

--- a/frontend/labs-chat/src/app/components/auth/ConfirmResetPasswordForm.tsx
+++ b/frontend/labs-chat/src/app/components/auth/ConfirmResetPasswordForm.tsx
@@ -7,6 +7,9 @@ import {
 import { useFormState } from "react-dom";
 import { handleConfirmResetPassword } from "@helpers/cognito-actions";
 import FormConfirmButton from "@components/FormConfirmButton";
+import FormWrapper from "@components/auth/ui/FormWrapper";
+import FormInput from "@components/auth/ui/FormInput";
+import FormErrorMessage from "./ui/FormErrorMessage";
 
 export default function ConfirmResetPasswordForm() {
   const [errorMessage, dispatch] = useFormState(
@@ -14,86 +17,14 @@ export default function ConfirmResetPasswordForm() {
     undefined,
   );
   return (
-    <form action={dispatch} className="w-full max-w-80 space-y-3">
-      <div className="flex-1 rounded-lg bg-gray-50 px-6 pb-4 pt-8">
-        <h1 className={`mb-3 text-2xl`}>Reset password.</h1>
-        <div className="w-full">
-          <div>
-            <label
-              className="mb-3 mt-5 block text-xs font-medium text-gray-900"
-              htmlFor="email"
-            >
-              Email
-            </label>
-            <div className="relative">
-              <input
-                className="peer block w-full rounded-md border border-gray-200 py-[9px] pl-10 text-sm outline-2 placeholder:text-gray-500"
-                id="email"
-                type="email"
-                name="email"
-                placeholder="Enter your email address"
-                required
-              />
-              <AtSymbolIcon className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
-            </div>
-          </div>
-          <div className="mt-4">
-            <label
-              className="mb-3 mt-5 block text-xs font-medium text-gray-900"
-              htmlFor="password"
-            >
-              New Password
-            </label>
-            <div className="relative">
-              <input
-                className="peer block w-full rounded-md border border-gray-200 py-[9px] pl-10 text-sm outline-2 placeholder:text-gray-500"
-                id="password"
-                type="password"
-                name="password"
-                placeholder="Enter password"
-                required
-                minLength={6}
-              />
-              <KeyIcon className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
-            </div>
-          </div>
-          <div className="mt-4">
-            <label
-              className="mb-3 mt-5 block text-xs font-medium text-gray-900"
-              htmlFor="code"
-            >
-              Confirmation Code
-            </label>
-            <div className="relative">
-              <input
-                className="peer block w-full rounded-md border border-gray-200 py-[9px] pl-10 text-sm outline-2 placeholder:text-gray-500"
-                id="code"
-                type="text"
-                name="code"
-                placeholder="Enter code"
-                required
-                minLength={6}
-              />
-              <KeyIcon className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
-            </div>
-          </div>
-        </div>
-        <FormConfirmButton label="Reset Password" />
-        <div className="flex h-8 items-end space-x-1">
-          <div
-            className="flex h-8 items-end space-x-1"
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            {errorMessage && (
-              <>
-                <ExclamationCircleIcon className="h-5 w-5 text-red-500" />
-                <p className="text-sm text-red-500">{errorMessage}</p>
-              </>
-            )}
-          </div>
-        </div>
-      </div>
-    </form>
+    <FormWrapper dispatch={dispatch} title="Reset Password">
+      <FormInput label="Email" type="email" unique_id="email" placeholder="Enter email" required IconComponent={AtSymbolIcon} />
+      <FormInput label="New Password" type="password" unique_id="password" placeholder="Enter password" required IconComponent={KeyIcon} />
+      <FormInput label="Confirm New Password" type="password" unique_id="password_confirm" placeholder="Enter password" required IconComponent={KeyIcon} />
+      <FormInput label="Code" type="text" unique_id="code" placeholder="Enter code" required />
+      <p className="text-xs text-slate-500">{"Enter the code you received in your email"}</p>
+      <FormConfirmButton label="Reset Password" />
+      <FormErrorMessage message={errorMessage} />
+    </FormWrapper>
   );
 }

--- a/frontend/labs-chat/src/app/components/auth/ConfirmResetPasswordForm.tsx
+++ b/frontend/labs-chat/src/app/components/auth/ConfirmResetPasswordForm.tsx
@@ -18,11 +18,40 @@ export default function ConfirmResetPasswordForm() {
   );
   return (
     <FormWrapper dispatch={dispatch} title="Reset Password">
-      <FormInput label="Email" type="email" unique_id="email" placeholder="Enter email" required IconComponent={AtSymbolIcon} />
-      <FormInput label="New Password" type="password" unique_id="password" placeholder="Enter password" required IconComponent={KeyIcon} />
-      <FormInput label="Confirm New Password" type="password" unique_id="password_confirm" placeholder="Enter password" required IconComponent={KeyIcon} />
-      <FormInput label="Code" type="text" unique_id="code" placeholder="Enter code" required />
-      <p className="text-xs text-slate-500">{"Enter the code you received in your email"}</p>
+      <FormInput
+        label="Email"
+        type="email"
+        unique_id="email"
+        placeholder="Enter email"
+        required
+        IconComponent={AtSymbolIcon}
+      />
+      <FormInput
+        label="New Password"
+        type="password"
+        unique_id="password"
+        placeholder="Enter password"
+        required
+        IconComponent={KeyIcon}
+      />
+      <FormInput
+        label="Confirm New Password"
+        type="password"
+        unique_id="password_confirm"
+        placeholder="Enter password"
+        required
+        IconComponent={KeyIcon}
+      />
+      <FormInput
+        label="Code"
+        type="text"
+        unique_id="code"
+        placeholder="Enter code"
+        required
+      />
+      <p className="text-xs text-slate-500">
+        {"Enter the code you received in your email"}
+      </p>
       <FormConfirmButton label="Reset Password" />
       <FormErrorMessage message={errorMessage} />
     </FormWrapper>

--- a/frontend/labs-chat/src/app/components/auth/ConfirmSignInWithNewPasswordForm.tsx
+++ b/frontend/labs-chat/src/app/components/auth/ConfirmSignInWithNewPasswordForm.tsx
@@ -3,6 +3,9 @@ import { ExclamationCircleIcon, KeyIcon } from "@heroicons/react/24/outline";
 import { useFormState } from "react-dom";
 import { handleSignInWithNewPassword } from "@helpers/cognito-actions";
 import FormConfirmButton from "@components/FormConfirmButton";
+import FormWrapper from "@components/auth/ui/FormWrapper";
+import FormErrorMessage from "@components/auth/ui/FormErrorMessage";
+import FormInput from "@components/auth/ui/FormInput";
 
 export default function ConfirmSignInWithNewPasswordForm() {
   const [errorMessage, dispatch] = useFormState(
@@ -10,69 +13,11 @@ export default function ConfirmSignInWithNewPasswordForm() {
     undefined,
   );
   return (
-    <form action={dispatch} className="space-y-3">
-      <div className="flex-1 rounded-lg bg-gray-50 px-6 pb-4 pt-8">
-        <h1 className={`mb-3 text-2xl`}>Reset password.</h1>
-        <div className="w-full">
-          <div className="mt-4">
-            <label
-              className="mb-3 mt-5 block text-xs font-medium text-gray-900"
-              htmlFor="new_password"
-            >
-              New Password
-            </label>
-            <div className="relative">
-              <input
-                className="peer block w-full rounded-md border border-gray-200 py-[9px] pl-10 text-sm outline-2 placeholder:text-gray-500"
-                id="new_password"
-                type="password"
-                name="new_password"
-                placeholder="Enter new password"
-                required
-                minLength={6}
-              />
-              <KeyIcon className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
-            </div>
-          </div>
-        </div>
-        <div className="w-full">
-          <div className="mt-4">
-            <label
-              className="mb-3 mt-5 block text-xs font-medium text-gray-900"
-              htmlFor="new_password_confirm"
-            >
-              New Password
-            </label>
-            <div className="relative">
-              <input
-                className="peer block w-full rounded-md border border-gray-200 py-[9px] pl-10 text-sm outline-2 placeholder:text-gray-500"
-                id="new_password_confirm"
-                type="password"
-                name="new_password_confirm"
-                placeholder="Enter new password"
-                required
-                minLength={6}
-              />
-              <KeyIcon className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
-            </div>
-          </div>
-        </div>
-        <FormConfirmButton label="Set New Password" />
-        <div className="flex h-8 items-end space-x-1">
-          <div
-            className="flex h-8 items-end space-x-1"
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            {errorMessage && (
-              <>
-                <ExclamationCircleIcon className="h-5 w-5 text-red-500" />
-                <p className="text-sm text-red-500">{errorMessage}</p>
-              </>
-            )}
-          </div>
-        </div>
-      </div>
-    </form>
+    <FormWrapper dispatch={dispatch} title="Set New Password">
+      <FormInput label="New password" type="password" unique_id="new_password" placeholder="Enter new password" required IconComponent={KeyIcon} />
+      <FormInput label="Confirm new password" type="password" unique_id="new_password_confirm" placeholder="Enter new password" required IconComponent={KeyIcon} />
+      <FormConfirmButton label="Set New Password" />
+      <FormErrorMessage message={errorMessage} />
+    </FormWrapper>
   );
 }

--- a/frontend/labs-chat/src/app/components/auth/ConfirmSignInWithNewPasswordForm.tsx
+++ b/frontend/labs-chat/src/app/components/auth/ConfirmSignInWithNewPasswordForm.tsx
@@ -1,11 +1,9 @@
 "use client";
-import { ExclamationCircleIcon, KeyIcon } from "@heroicons/react/24/outline";
+import { KeyIcon } from "@heroicons/react/24/outline";
 import { useFormState } from "react-dom";
 import { handleSignInWithNewPassword } from "@helpers/cognito-actions";
 import FormConfirmButton from "@components/FormConfirmButton";
-import FormWrapper from "@components/auth/ui/FormWrapper";
-import FormErrorMessage from "@components/auth/ui/FormErrorMessage";
-import FormInput from "@components/auth/ui/FormInput";
+import { FormWrapper, FormInput, FormErrorMessage } from "@components/auth/ui";
 
 export default function ConfirmSignInWithNewPasswordForm() {
   const [errorMessage, dispatch] = useFormState(

--- a/frontend/labs-chat/src/app/components/auth/ConfirmSignInWithNewPasswordForm.tsx
+++ b/frontend/labs-chat/src/app/components/auth/ConfirmSignInWithNewPasswordForm.tsx
@@ -14,8 +14,22 @@ export default function ConfirmSignInWithNewPasswordForm() {
   );
   return (
     <FormWrapper dispatch={dispatch} title="Set New Password">
-      <FormInput label="New password" type="password" unique_id="new_password" placeholder="Enter new password" required IconComponent={KeyIcon} />
-      <FormInput label="Confirm new password" type="password" unique_id="new_password_confirm" placeholder="Enter new password" required IconComponent={KeyIcon} />
+      <FormInput
+        label="New password"
+        type="password"
+        unique_id="new_password"
+        placeholder="Enter new password"
+        required
+        IconComponent={KeyIcon}
+      />
+      <FormInput
+        label="Confirm new password"
+        type="password"
+        unique_id="new_password_confirm"
+        placeholder="Enter new password"
+        required
+        IconComponent={KeyIcon}
+      />
       <FormConfirmButton label="Set New Password" />
       <FormErrorMessage message={errorMessage} />
     </FormWrapper>

--- a/frontend/labs-chat/src/app/components/auth/ConfirmSignUpForm.tsx
+++ b/frontend/labs-chat/src/app/components/auth/ConfirmSignUpForm.tsx
@@ -3,7 +3,6 @@
 import {
   AtSymbolIcon,
   KeyIcon,
-  ExclamationCircleIcon,
   LockClosedIcon,
   ArrowLeftCircleIcon,
 } from "@heroicons/react/24/outline";

--- a/frontend/labs-chat/src/app/components/auth/ConfirmSignUpForm.tsx
+++ b/frontend/labs-chat/src/app/components/auth/ConfirmSignUpForm.tsx
@@ -21,7 +21,9 @@ export default function ConfirmSignUpForm() {
 
   return (
     <FormWrapper dispatch={dispatch} title="Confirm Sign Up">
-      <p className="text-xs text-slate-500">{"Check your email for the code"}</p>
+      <p className="text-xs text-slate-500">
+        {"Check your email for the code"}
+      </p>
       <div>
         <label
           className="mb-3 mt-5 block text-xs font-medium text-gray-900"

--- a/frontend/labs-chat/src/app/components/auth/ConfirmSignUpForm.tsx
+++ b/frontend/labs-chat/src/app/components/auth/ConfirmSignUpForm.tsx
@@ -12,99 +12,83 @@ import { handleConfirmSignUp } from "@/helpers/cognito-actions";
 import FormConfirmButton from "@components/FormConfirmButton";
 import { useSearchParams } from "next/navigation";
 import TextNavLink from "@components/TextNavLink";
+import FormErrorMessage from "@components/auth/ui/FormErrorMessage";
+import FormWrapper from "@components/auth/ui/FormWrapper";
 
 export default function ConfirmSignUpForm() {
   const searchParams = useSearchParams();
   const [errorMessage, dispatch] = useFormState(handleConfirmSignUp, null);
 
   return (
-    <form action={dispatch} className="w-full max-w-80 space-y-3">
-      <div className="flex-1 rounded-lg bg-gray-50 px-6 pb-8 pt-8">
-        <h1 className={`mb-3 text-2xl`}>Confirm Your Email</h1>
-        <div className="w-full">
-          <div>
-            <label
-              className="mb-3 mt-5 block text-xs font-medium text-gray-900"
-              htmlFor="email"
-            >
-              Email
-            </label>
-            <div className="relative">
-              <input
-                className="peer block w-full rounded-md border border-gray-200 py-[9px] pl-10 text-sm outline-2 placeholder:text-gray-500"
-                id="email"
-                type="email"
-                name="email"
-                defaultValue={searchParams.get("email") ?? ""}
-                placeholder="Enter your email address"
-                required
-              />
-              <AtSymbolIcon className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
-            </div>
-          </div>
-          <div>
-            <label
-              className="mb-3 mt-5 block text-xs font-medium text-gray-900"
-              htmlFor="password"
-            >
-              Password
-            </label>
-            <div className="relative">
-              <input
-                className="peer block w-full rounded-md border border-gray-200 py-[9px] pl-10 text-sm outline-2 placeholder:text-gray-500"
-                id="password"
-                type="password"
-                name="password"
-                placeholder="Enter your password"
-                required
-              />
-              <LockClosedIcon className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
-            </div>
-          </div>
-          <div className="mt-4">
-            <label
-              className="mb-3 mt-5 block text-xs font-medium text-gray-900"
-              htmlFor="code"
-            >
-              Code
-            </label>
-            <div className="relative">
-              <input
-                className="peer block w-full rounded-md border border-gray-200 py-[9px] pl-10 text-sm outline-2 placeholder:text-gray-500"
-                id="code"
-                type="text"
-                name="code"
-                placeholder="Enter code"
-                required
-                minLength={6}
-              />
-              <KeyIcon className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
-            </div>
-          </div>
+    <FormWrapper dispatch={dispatch} title="Confirm Sign Up">
+      <p className="text-xs text-slate-500">{"Check your email for the code"}</p>
+      <div>
+        <label
+          className="mb-3 mt-5 block text-xs font-medium text-gray-900"
+          htmlFor="email"
+        >
+          Email
+        </label>
+        <div className="relative">
+          <input
+            className="peer block w-full rounded-md border border-gray-200 py-[9px] pl-10 text-sm outline-2 placeholder:text-gray-500"
+            id="email"
+            type="email"
+            name="email"
+            defaultValue={searchParams.get("email") ?? ""}
+            placeholder="Enter your email address"
+            required
+          />
+          <AtSymbolIcon className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
         </div>
-        <FormConfirmButton label="Confirm" />
-        {errorMessage && (
-          <div className="flex h-16 items-end space-x-1">
-            <div
-              className="flex items-end"
-              aria-live="polite"
-              aria-atomic="true"
-            >
-              <div className="flex space-x-3">
-                <ExclamationCircleIcon className="h-14 w-14 text-red-500" />
-                <p className="text-sm text-red-500">{errorMessage}</p>
-              </div>
-            </div>
-          </div>
-        )}
-
-        <ResendCodeLink />
-        <TextNavLink to="/auth/login">
-          <ArrowLeftCircleIcon className="h-6 w-6 text-blue-500" />
-          <div>Back to log in</div>
-        </TextNavLink>
       </div>
-    </form>
+      <div>
+        <label
+          className="mb-3 mt-5 block text-xs font-medium text-gray-900"
+          htmlFor="password"
+        >
+          Password
+        </label>
+        <div className="relative">
+          <input
+            className="peer block w-full rounded-md border border-gray-200 py-[9px] pl-10 text-sm outline-2 placeholder:text-gray-500"
+            id="password"
+            type="password"
+            name="password"
+            placeholder="Enter your password"
+            required
+          />
+          <LockClosedIcon className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
+        </div>
+      </div>
+      <div className="mt-4">
+        <label
+          className="mb-3 mt-5 block text-xs font-medium text-gray-900"
+          htmlFor="code"
+        >
+          Code
+        </label>
+        <div className="relative">
+          <input
+            className="peer block w-full rounded-md border border-gray-200 py-[9px] pl-10 text-sm outline-2 placeholder:text-gray-500"
+            id="code"
+            type="text"
+            name="code"
+            placeholder="Enter code"
+            required
+            minLength={6}
+          />
+          <KeyIcon className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
+        </div>
+      </div>
+      <FormConfirmButton label="Confirm" />
+      <FormErrorMessage message={errorMessage} />
+      <ResendCodeLink />
+      <TextNavLink to="/auth/login">
+        <ArrowLeftCircleIcon className="h-6 w-6 text-blue-500" />
+        <div>Back to log in</div>
+      </TextNavLink>
+    </FormWrapper>
   );
 }
 

--- a/frontend/labs-chat/src/app/components/auth/ConfirmSignUpForm.tsx
+++ b/frontend/labs-chat/src/app/components/auth/ConfirmSignUpForm.tsx
@@ -11,8 +11,7 @@ import { handleConfirmSignUp } from "@/helpers/cognito-actions";
 import FormConfirmButton from "@components/FormConfirmButton";
 import { useSearchParams } from "next/navigation";
 import TextNavLink from "@components/TextNavLink";
-import FormErrorMessage from "@components/auth/ui/FormErrorMessage";
-import FormWrapper from "@components/auth/ui/FormWrapper";
+import { FormWrapper, FormInput, FormErrorMessage } from "@components/auth/ui";
 
 export default function ConfirmSignUpForm() {
   const searchParams = useSearchParams();
@@ -23,65 +22,33 @@ export default function ConfirmSignUpForm() {
       <p className="text-xs text-slate-500">
         {"Check your email for the code"}
       </p>
-      <div>
-        <label
-          className="mb-3 mt-5 block text-xs font-medium text-gray-900"
-          htmlFor="email"
-        >
-          Email
-        </label>
-        <div className="relative">
-          <input
-            className="peer block w-full rounded-md border border-gray-200 py-[9px] pl-10 text-sm outline-2 placeholder:text-gray-500"
-            id="email"
-            type="email"
-            name="email"
-            defaultValue={searchParams.get("email") ?? ""}
-            placeholder="Enter your email address"
-            required
-          />
-          <AtSymbolIcon className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
-        </div>
-      </div>
-      <div>
-        <label
-          className="mb-3 mt-5 block text-xs font-medium text-gray-900"
-          htmlFor="password"
-        >
-          Password
-        </label>
-        <div className="relative">
-          <input
-            className="peer block w-full rounded-md border border-gray-200 py-[9px] pl-10 text-sm outline-2 placeholder:text-gray-500"
-            id="password"
-            type="password"
-            name="password"
-            placeholder="Enter your password"
-            required
-          />
-          <LockClosedIcon className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
-        </div>
-      </div>
-      <div className="mt-4">
-        <label
-          className="mb-3 mt-5 block text-xs font-medium text-gray-900"
-          htmlFor="code"
-        >
-          Code
-        </label>
-        <div className="relative">
-          <input
-            className="peer block w-full rounded-md border border-gray-200 py-[9px] pl-10 text-sm outline-2 placeholder:text-gray-500"
-            id="code"
-            type="text"
-            name="code"
-            placeholder="Enter code"
-            required
-            minLength={6}
-          />
-          <KeyIcon className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
-        </div>
-      </div>
+      <FormInput
+        label="Email"
+        type="email"
+        unique_id="email"
+        placeholder="Enter email"
+        required
+        defaultValue={searchParams.get("email") ?? ""}
+        IconComponent={AtSymbolIcon}
+      />
+
+      <FormInput
+        label="Password"
+        type="password"
+        unique_id="password"
+        placeholder="Enter password"
+        required
+        minLength={6}
+        IconComponent={LockClosedIcon}
+      />
+      <FormInput
+        label="Code"
+        type="text"
+        unique_id="code"
+        placeholder="Enter code"
+        required
+        IconComponent={KeyIcon}
+      />
       <FormConfirmButton label="Confirm" />
       <FormErrorMessage message={errorMessage} />
       <ResendCodeLink />

--- a/frontend/labs-chat/src/app/components/auth/LoginForm.tsx
+++ b/frontend/labs-chat/src/app/components/auth/LoginForm.tsx
@@ -17,8 +17,23 @@ export default function LoginForm() {
   const [errorMessage, dispatch] = useFormState(handleSignIn, undefined);
   return (
     <FormWrapper dispatch={dispatch} title="Log In">
-      <FormInput label="Email" type="email" unique_id="email" placeholder="Enter your email address" required IconComponent={AtSymbolIcon} />
-      <FormInput label="Password" type="password" unique_id="password" placeholder="Enter your password" minLength={6} required IconComponent={KeyIcon} />
+      <FormInput
+        label="Email"
+        type="email"
+        unique_id="email"
+        placeholder="Enter your email address"
+        required
+        IconComponent={AtSymbolIcon}
+      />
+      <FormInput
+        label="Password"
+        type="password"
+        unique_id="password"
+        placeholder="Enter your password"
+        minLength={6}
+        required
+        IconComponent={KeyIcon}
+      />
       <FormConfirmButton label="Log in" />
       <div className="flex h-8 items-end space-x-1" />
       <TextNavLink to="/auth/signUp" border>
@@ -31,6 +46,6 @@ export default function LoginForm() {
         Need to confirm a code?
       </TextNavLink>
       <FormErrorMessage message={errorMessage} />
-    </FormWrapper >
+    </FormWrapper>
   );
 }

--- a/frontend/labs-chat/src/app/components/auth/LoginForm.tsx
+++ b/frontend/labs-chat/src/app/components/auth/LoginForm.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import {
-  AtSymbolIcon,
-  KeyIcon,
-  ExclamationCircleIcon,
-} from "@heroicons/react/24/outline";
+import { AtSymbolIcon, KeyIcon } from "@heroicons/react/24/outline";
 import { useFormState } from "react-dom";
 import { handleSignIn } from "@/helpers/cognito-actions";
 import FormConfirmButton from "@components/FormConfirmButton";

--- a/frontend/labs-chat/src/app/components/auth/LoginForm.tsx
+++ b/frontend/labs-chat/src/app/components/auth/LoginForm.tsx
@@ -5,9 +5,7 @@ import { useFormState } from "react-dom";
 import { handleSignIn } from "@/helpers/cognito-actions";
 import FormConfirmButton from "@components/FormConfirmButton";
 import TextNavLink from "@components/TextNavLink";
-import FormInput from "@components/auth/ui/FormInput";
-import FormWrapper from "@components/auth/ui/FormWrapper";
-import FormErrorMessage from "@components/auth/ui/FormErrorMessage";
+import { FormWrapper, FormInput, FormErrorMessage } from "@components/auth/ui";
 
 export default function LoginForm() {
   const [errorMessage, dispatch] = useFormState(handleSignIn, undefined);

--- a/frontend/labs-chat/src/app/components/auth/LoginForm.tsx
+++ b/frontend/labs-chat/src/app/components/auth/LoginForm.tsx
@@ -9,81 +9,28 @@ import { useFormState } from "react-dom";
 import { handleSignIn } from "@/helpers/cognito-actions";
 import FormConfirmButton from "@components/FormConfirmButton";
 import TextNavLink from "@components/TextNavLink";
+import FormInput from "@components/auth/ui/FormInput";
+import FormWrapper from "@components/auth/ui/FormWrapper";
+import FormErrorMessage from "@components/auth/ui/FormErrorMessage";
 
 export default function LoginForm() {
   const [errorMessage, dispatch] = useFormState(handleSignIn, undefined);
   return (
-    <form action={dispatch} className="w-full max-w-80 space-y-3">
-      <div className="flex-1 rounded-lg bg-gray-50 px-6 pb-4 pt-8">
-        <h1 className={`mb-3 text-2xl`}>Log In</h1>
-        <div className="w-full">
-          <div>
-            <label
-              className="mb-3 mt-5 block text-xs font-medium text-gray-900"
-              htmlFor="email"
-            >
-              Email
-            </label>
-            <div className="relative">
-              <input
-                className="peer block w-full rounded-md border border-gray-200 py-[9px] pl-10 text-sm outline-2 placeholder:text-gray-500"
-                id="email"
-                type="email"
-                name="email"
-                placeholder="Enter your email address"
-                required
-              />
-              <AtSymbolIcon className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
-            </div>
-          </div>
-          <div className="mt-4">
-            <label
-              className="mb-3 mt-5 block text-xs font-medium text-gray-900"
-              htmlFor="password"
-            >
-              Password
-            </label>
-            <div className="relative">
-              <input
-                className="peer block w-full rounded-md border border-gray-200 py-[9px] pl-10 text-sm outline-2 placeholder:text-gray-500"
-                id="password"
-                type="password"
-                name="password"
-                placeholder="Enter password"
-                required
-                minLength={6}
-              />
-              <KeyIcon className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
-            </div>
-          </div>
-        </div>
-
-        <FormConfirmButton label="Log in" />
-        <div className="flex h-8 items-end space-x-1"></div>
-        <TextNavLink to="/auth/signUp" border>
-          {"Don't have an account? "} Sign up.
-        </TextNavLink>
-        <TextNavLink to="/auth/resetPassword/submit" border>
-          Forgot Password?
-        </TextNavLink>
-        <TextNavLink to="/auth/confirmSignUp" border>
-          Need to confirm a code?
-        </TextNavLink>
-        <div className="flex h-8 items-end space-x-1">
-          <div
-            className="flex h-8 items-end space-x-1"
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            {errorMessage && (
-              <>
-                <ExclamationCircleIcon className="h-5 w-5 text-red-500" />
-                <p className="text-sm text-red-500">{errorMessage}</p>
-              </>
-            )}
-          </div>
-        </div>
-      </div>
-    </form>
+    <FormWrapper dispatch={dispatch} title="Log In">
+      <FormInput label="Email" type="email" unique_id="email" placeholder="Enter your email address" required IconComponent={AtSymbolIcon} />
+      <FormInput label="Password" type="password" unique_id="password" placeholder="Enter your password" minLength={6} required IconComponent={KeyIcon} />
+      <FormConfirmButton label="Log in" />
+      <div className="flex h-8 items-end space-x-1" />
+      <TextNavLink to="/auth/signUp" border>
+        {"Don't have an account? "} Sign up.
+      </TextNavLink>
+      <TextNavLink to="/auth/resetPassword/submit" border>
+        Forgot Password?
+      </TextNavLink>
+      <TextNavLink to="/auth/confirmSignUp" border>
+        Need to confirm a code?
+      </TextNavLink>
+      <FormErrorMessage message={errorMessage} />
+    </FormWrapper >
   );
 }

--- a/frontend/labs-chat/src/app/components/auth/SendVerificationCodeForm.tsx
+++ b/frontend/labs-chat/src/app/components/auth/SendVerificationCodeForm.tsx
@@ -11,6 +11,7 @@ import { useFormState } from "react-dom";
 import FormConfirmButton from "@components/FormConfirmButton";
 import { useSearchParams } from "next/navigation";
 import TextNavLink from "@components/TextNavLink";
+import { FormWrapper, FormInput, FormErrorMessage } from "@components/auth/ui";
 
 export default function SendVerificationCodeForm() {
   const searchParams = useSearchParams();
@@ -19,56 +20,22 @@ export default function SendVerificationCodeForm() {
     errorMessage: "",
   });
   return (
-    <form action={dispatch} className="w-full max-w-80 space-y-3">
-      <div className="flex-1 rounded-lg bg-gray-50 px-6 pb-4 pt-8">
-        <h1 className={`mb-3 text-2xl`}>Resend Verification Code</h1>
-        <div className="w-full">
-          <div>
-            <label
-              className="mb-3 mt-5 block text-xs font-medium text-gray-900"
-              htmlFor="email"
-            >
-              Email
-            </label>
-            <div className="relative">
-              <input
-                className="peer block w-full rounded-md border border-gray-200 py-[9px] pl-10 text-sm outline-2 placeholder:text-gray-500"
-                id="email"
-                type="email"
-                name="email"
-                defaultValue={searchParams.get("email") ?? ""}
-                placeholder="Enter your email address"
-                required
-              />
-              <AtSymbolIcon className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
-            </div>
-          </div>
-          <FormConfirmButton label="Send" />
-          <div className="flex h-8 items-end space-x-1">
-            <div
-              className="flex h-8 items-end space-x-1"
-              aria-live="polite"
-              aria-atomic="true"
-            >
-              {response?.errorMessage && (
-                <>
-                  <ExclamationCircleIcon className="h-5 w-5 text-red-500" />
-                  <p className="text-sm text-red-500">
-                    {response.errorMessage}
-                  </p>
-                </>
-              )}
-              {response?.message && (
-                <p className="text-sm text-green-500">{response.message}</p>
-              )}
-            </div>
-          </div>
-          <TextNavLink to="/auth/confirmSignUp">
-            <ArrowLeftCircleIcon className="h-6 w-6 text-blue-500" />
-            <div>Back to confirm account</div>
-          </TextNavLink>
-        </div>
-      </div>
-    </form>
+    <FormWrapper dispatch={dispatch} title="Send Verification Code">
+      <FormInput
+        label="Email"
+        type="email"
+        unique_id="email"
+        placeholder="Enter email"
+        required
+        defaultValue={searchParams.get("email") ?? ""}
+        IconComponent={AtSymbolIcon}
+      />
+      <FormConfirmButton label="Send" />
+      <FormErrorMessage message={response?.errorMessage ?? ""} />
+      <TextNavLink to="/auth/confirmSignUp">
+        <ArrowLeftCircleIcon className="h-6 w-6 text-blue-500" />
+        <div>Back to confirm account</div>
+      </TextNavLink>
+    </FormWrapper>
   );
 }

--- a/frontend/labs-chat/src/app/components/auth/SignUpForm.tsx
+++ b/frontend/labs-chat/src/app/components/auth/SignUpForm.tsx
@@ -1,4 +1,5 @@
 "use client";
+import React from "react";
 
 import {
   AtSymbolIcon,
@@ -11,96 +12,47 @@ import { useFormState } from "react-dom";
 import { handleSignUp } from "@helpers/cognito-actions";
 import FormConfirmButton from "@components/FormConfirmButton";
 import TextNavLink from "@components/TextNavLink";
+import { FormWrapper, FormInput, FormErrorMessage } from "@components/auth/ui";
 
 export default function SignUpForm() {
   const [errorMessage, dispatch] = useFormState(handleSignUp, undefined);
+
   return (
-    <form action={dispatch} className="w-full max-w-md space-y-3 p-8">
-      <div className="flex-1 rounded-lg bg-gray-50 px-6 pb-4 pt-8">
-        <h1 className={`mb-3 text-2xl`}>Create an Account</h1>
-        <div className="w-full">
-          <div>
-            <label
-              className="mb-3 mt-5 block text-xs font-medium text-gray-900"
-              htmlFor="name"
-            >
-              Name
-            </label>
-            <div className="relative">
-              <input
-                className="peer block w-full rounded-md border border-gray-200 py-[9px] pl-10 text-sm outline-2 placeholder:text-gray-500"
-                id="name"
-                type="text"
-                name="name"
-                minLength={4}
-                placeholder="Enter your name"
-                required
-              />
-              <UserCircleIcon className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
-            </div>
-          </div>
-          <div className="mt-4">
-            <label
-              className="mb-3 mt-5 block text-xs font-medium text-gray-900"
-              htmlFor="email"
-            >
-              Email
-            </label>
-            <div className="relative">
-              <input
-                className="peer block w-full rounded-md border border-gray-200 py-[9px] pl-10 text-sm outline-2 placeholder:text-gray-500"
-                id="email"
-                type="email"
-                name="email"
-                placeholder="Enter your email address"
-                required
-              />
-              <AtSymbolIcon className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
-            </div>
-          </div>
-          <div className="mt-4">
-            <label
-              className="mb-3 mt-5 block text-xs font-medium text-gray-900"
-              htmlFor="password"
-            >
-              Password
-            </label>
-            <div className="relative">
-              <input
-                className="peer block w-full rounded-md border border-gray-200 py-[9px] pl-10 text-sm outline-2 placeholder:text-gray-500"
-                id="password"
-                type="password"
-                name="password"
-                placeholder="Enter password"
-                required
-                minLength={6}
-              />
-              <KeyIcon className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
-            </div>
-          </div>
-        </div>
-        <FormConfirmButton label="Create account" />
-        <div className="flex justify-center">
-          <TextNavLink to="/auth/login">
-            <ArrowLeftCircleIcon className="h-6 w-6 text-blue-500" />
-            <div>Back to log in</div>
-          </TextNavLink>
-        </div>
-        <div className="flex h-8 items-end space-x-1">
-          <div
-            className="flex h-8 items-end space-x-1"
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            {errorMessage && (
-              <>
-                <ExclamationCircleIcon className="h-5 w-5 text-red-500" />
-                <p className="text-sm text-red-500">{errorMessage}</p>
-              </>
-            )}
-          </div>
-        </div>
+    <FormWrapper dispatch={dispatch} title="Sign Up">
+      <FormInput
+        label="Name"
+        unique_id="name"
+        type="text"
+        IconComponent={UserCircleIcon}
+        minLength={4}
+        placeholder="Enter your name"
+        required
+      />
+      <FormInput
+        label="Email"
+        unique_id="email"
+        type="email"
+        IconComponent={AtSymbolIcon}
+        placeholder="Enter your email address"
+        required
+      />
+      <FormInput
+        label="Password"
+        unique_id="password"
+        type="password"
+        IconComponent={KeyIcon}
+        placeholder="Enter password"
+        required
+        minLength={6}
+      />
+      <FormConfirmButton label="Create account" />
+      <div className="flex justify-center">
+        <TextNavLink to="/auth/login">
+          <ArrowLeftCircleIcon className="h-6 w-6 text-blue-500" />
+          <div>Back to log in</div>
+        </TextNavLink>
       </div>
-    </form>
+      <FormErrorMessage message={errorMessage} />
+    </FormWrapper>
   );
 }

--- a/frontend/labs-chat/src/app/components/auth/SubmitResetPasswordForm.tsx
+++ b/frontend/labs-chat/src/app/components/auth/SubmitResetPasswordForm.tsx
@@ -8,51 +8,23 @@ import { useFormState } from "react-dom";
 import { handleResetPassword } from "@helpers/cognito-actions";
 import FormConfirmButton from "../FormConfirmButton";
 import TextNavLink from "../TextNavLink";
+import { FormWrapper, FormInput, FormErrorMessage } from "@components/auth/ui";
 
 export default function SubmitResetPasswordForm() {
   const [errorMessage, dispatch] = useFormState(handleResetPassword, undefined);
   return (
-    <form action={dispatch} className="max-w-lg space-y-3">
-      <div className="flex-1 rounded-lg bg-gray-50 px-6 pb-4 pt-8">
-        <h1 className={`mb-3 text-2xl`}>Get a New Verification Code</h1>
-        <div className="w-full">
-          <div>
-            <label
-              className="mb-3 mt-5 block text-xs font-medium text-gray-900"
-              htmlFor="email"
-            >
-              Email
-            </label>
-            <div className="relative">
-              <input
-                className="peer block w-full rounded-md border border-gray-200 py-[9px] pl-10 text-sm outline-2 placeholder:text-gray-500"
-                id="email"
-                type="email"
-                name="email"
-                placeholder="Enter your email address"
-                required
-              />
-              <AtSymbolIcon className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
-            </div>
-          </div>
-        </div>
-        <FormConfirmButton label="Submit" />
-        <div className="flex h-8 items-end space-x-1">
-          <div
-            className="flex h-8 items-end space-x-1"
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            {errorMessage && (
-              <>
-                <ExclamationCircleIcon className="h-5 w-5 text-red-500" />
-                <p className="text-sm text-red-500">{errorMessage}</p>
-              </>
-            )}
-          </div>
-        </div>
-        <TextNavLink to={"/auth/login"}>Back to login</TextNavLink>
-      </div>
-    </form>
+    <FormWrapper dispatch={dispatch} title="Get a New Verification Code">
+      <FormInput
+        label="Email"
+        unique_id="email"
+        type="email"
+        IconComponent={AtSymbolIcon}
+        placeholder="Enter your email address"
+        required
+      />
+      <FormConfirmButton label="Submit" />
+      <FormErrorMessage message={errorMessage} />
+      <TextNavLink to={"/auth/login"}>Back to login</TextNavLink>
+    </FormWrapper>
   );
 }

--- a/frontend/labs-chat/src/app/components/auth/ui/FormErrorMessage.tsx
+++ b/frontend/labs-chat/src/app/components/auth/ui/FormErrorMessage.tsx
@@ -1,26 +1,26 @@
-import { ExclamationCircleIcon } from "@heroicons/react/24/outline"
+import { ExclamationCircleIcon } from "@heroicons/react/24/outline";
 
 interface FormErrorMessageProps {
-    message: string | undefined;
+  message: string | undefined;
 }
 
 const FormErrorMessage = ({ message }: FormErrorMessageProps) => {
-    return (
-        <div className="flex items-end space-x-1 mt-5">
-            <div
-                className="flex items-end space-x-1"
-                aria-live="polite"
-                aria-atomic="true"
-            >
-                {message && (
-                    <div className="flex space-x-2">
-                        <ExclamationCircleIcon className="h-5 w-5 text-red-500" />
-                        <p className="text-sm text-red-500">{message}</p>
-                    </div>
-                )}
-            </div>
-        </div>
-    )
-}
+  return (
+    <div className="mt-5 flex items-end space-x-1">
+      <div
+        className="flex items-end space-x-1"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {message && (
+          <div className="flex space-x-2">
+            <ExclamationCircleIcon className="h-5 w-5 text-red-500" />
+            <p className="text-sm text-red-500">{message}</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
 
 export default FormErrorMessage;

--- a/frontend/labs-chat/src/app/components/auth/ui/FormErrorMessage.tsx
+++ b/frontend/labs-chat/src/app/components/auth/ui/FormErrorMessage.tsx
@@ -1,0 +1,26 @@
+import { ExclamationCircleIcon } from "@heroicons/react/24/outline"
+
+interface FormErrorMessageProps {
+    message: string | undefined;
+}
+
+const FormErrorMessage = ({ message }: FormErrorMessageProps) => {
+    return (
+        <div className="flex items-end space-x-1 mt-5">
+            <div
+                className="flex items-end space-x-1"
+                aria-live="polite"
+                aria-atomic="true"
+            >
+                {message && (
+                    <div className="flex space-x-2">
+                        <ExclamationCircleIcon className="h-5 w-5 text-red-500" />
+                        <p className="text-sm text-red-500">{message}</p>
+                    </div>
+                )}
+            </div>
+        </div>
+    )
+}
+
+export default FormErrorMessage;

--- a/frontend/labs-chat/src/app/components/auth/ui/FormInput.tsx
+++ b/frontend/labs-chat/src/app/components/auth/ui/FormInput.tsx
@@ -1,0 +1,33 @@
+import React, { JSXElementConstructor } from 'react';
+
+interface FormInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+    unique_id: string;
+    label: string;
+    type: string;
+    IconComponent?: any;
+}
+
+const FormInput = ({label, unique_id, type, IconComponent, ...rest}: FormInputProps) => {
+    return (
+        <div>
+            <label
+              className="mb-3 mt-5 block text-xs font-medium text-gray-900"
+              htmlFor={unique_id}
+            >
+              {label}
+            </label>
+            <div className="relative">
+              <input
+                className={`peer block w-full rounded-md border border-gray-200 py-[9px] ${IconComponent ? 'pl-10' : 'pl-3'} text-sm outline-2 placeholder:text-gray-500`}
+                id={unique_id}
+                type={type}
+                name={unique_id}
+                {...rest}
+              />
+              {IconComponent && <IconComponent className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />}
+            </div>
+          </div>
+    )
+}
+
+export default FormInput;

--- a/frontend/labs-chat/src/app/components/auth/ui/FormInput.tsx
+++ b/frontend/labs-chat/src/app/components/auth/ui/FormInput.tsx
@@ -1,4 +1,4 @@
-import React, { JSXElementConstructor } from "react";
+import React from "react";
 
 interface FormInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   unique_id: string;

--- a/frontend/labs-chat/src/app/components/auth/ui/FormInput.tsx
+++ b/frontend/labs-chat/src/app/components/auth/ui/FormInput.tsx
@@ -1,33 +1,41 @@
-import React, { JSXElementConstructor } from 'react';
+import React, { JSXElementConstructor } from "react";
 
 interface FormInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
-    unique_id: string;
-    label: string;
-    type: string;
-    IconComponent?: any;
+  unique_id: string;
+  label: string;
+  type: string;
+  IconComponent?: any;
 }
 
-const FormInput = ({label, unique_id, type, IconComponent, ...rest}: FormInputProps) => {
-    return (
-        <div>
-            <label
-              className="mb-3 mt-5 block text-xs font-medium text-gray-900"
-              htmlFor={unique_id}
-            >
-              {label}
-            </label>
-            <div className="relative">
-              <input
-                className={`peer block w-full rounded-md border border-gray-200 py-[9px] ${IconComponent ? 'pl-10' : 'pl-3'} text-sm outline-2 placeholder:text-gray-500`}
-                id={unique_id}
-                type={type}
-                name={unique_id}
-                {...rest}
-              />
-              {IconComponent && <IconComponent className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />}
-            </div>
-          </div>
-    )
-}
+const FormInput = ({
+  label,
+  unique_id,
+  type,
+  IconComponent,
+  ...rest
+}: FormInputProps) => {
+  return (
+    <div>
+      <label
+        className="mb-3 mt-5 block text-xs font-medium text-gray-900"
+        htmlFor={unique_id}
+      >
+        {label}
+      </label>
+      <div className="relative">
+        <input
+          className={`peer block w-full rounded-md border border-gray-200 py-[9px] ${IconComponent ? "pl-10" : "pl-3"} text-sm outline-2 placeholder:text-gray-500`}
+          id={unique_id}
+          type={type}
+          name={unique_id}
+          {...rest}
+        />
+        {IconComponent && (
+          <IconComponent className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
+        )}
+      </div>
+    </div>
+  );
+};
 
 export default FormInput;

--- a/frontend/labs-chat/src/app/components/auth/ui/FormWrapper.tsx
+++ b/frontend/labs-chat/src/app/components/auth/ui/FormWrapper.tsx
@@ -1,22 +1,20 @@
-import React from 'react';
+import React from "react";
 
 interface FormWrapperProps {
-    children: React.ReactNode;
-    dispatch: any;
-    title: string;
+  children: React.ReactNode;
+  dispatch: any;
+  title: string;
 }
 
 const FormWrapper = ({ children, dispatch, title }: FormWrapperProps) => {
-    return (
-        <form action={dispatch} className="w-full max-w-80 space-y-3">
-            <div className="flex-1 rounded-lg bg-gray-50 px-6 pb-4 pt-8">
-                <h1 className={`mb-3 text-2xl`}>{title}</h1>
-                <div className="w-full">
-                {children}
-                </div>
-            </div>
-        </form>
-    )
-}
+  return (
+    <form action={dispatch} className="w-full max-w-80 space-y-3">
+      <div className="flex-1 rounded-lg bg-gray-50 px-6 pb-4 pt-8">
+        <h1 className={`mb-3 text-2xl`}>{title}</h1>
+        <div className="w-full">{children}</div>
+      </div>
+    </form>
+  );
+};
 
 export default FormWrapper;

--- a/frontend/labs-chat/src/app/components/auth/ui/FormWrapper.tsx
+++ b/frontend/labs-chat/src/app/components/auth/ui/FormWrapper.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+interface FormWrapperProps {
+    children: React.ReactNode;
+    dispatch: any;
+    title: string;
+}
+
+const FormWrapper = ({ children, dispatch, title }: FormWrapperProps) => {
+    return (
+        <form action={dispatch} className="w-full max-w-80 space-y-3">
+            <div className="flex-1 rounded-lg bg-gray-50 px-6 pb-4 pt-8">
+                <h1 className={`mb-3 text-2xl`}>{title}</h1>
+                <div className="w-full">
+                {children}
+                </div>
+            </div>
+        </form>
+    )
+}
+
+export default FormWrapper;

--- a/frontend/labs-chat/src/app/components/auth/ui/index.ts
+++ b/frontend/labs-chat/src/app/components/auth/ui/index.ts
@@ -1,0 +1,3 @@
+export { default as FormErrorMessage } from "./FormErrorMessage";
+export { default as FormInput } from "./FormInput";
+export { default as FormWrapper } from "./FormWrapper";


### PR DESCRIPTION
### PR Summary
Creating reusable components to use instead of repeating the same tailwind and components over and over again.

New components are placed in components/auth/ui/ folder

#### New Components
- FormWrapper
- FormInput
- FormErrorMessage

#### Updated Pages/Forms
- ConfirmResetPasswordForm ✅
- ConfirmSignInWithNewPasswordForm ✅
- ConfirmSignUpForm ✅
- LoginForm ✅
- SendVerificationCodeForm ✅
- SignUpForm ✅
- SubmitResetPasswordForm ✅