### PR TITLE
Lc 67 fix linting process

### DIFF
--- a/frontend/labs-chat/.husky/pre-commit
+++ b/frontend/labs-chat/.husky/pre-commit
@@ -1,3 +1,2 @@
 cd frontend/labs-chat
-npx lint-staged
-npm run prettier:fix
+npx lint-staged --allow-empty

--- a/frontend/labs-chat/.lintstagedrc.js
+++ b/frontend/labs-chat/.lintstagedrc.js
@@ -5,6 +5,14 @@ const buildEslintCommand = (filenames) =>
     .map((f) => path.relative(process.cwd(), f))
     .join(" --file ")}`;
 
+const runPrettierCommand = (filenames) =>
+  `npx prettier ${filenames
+    .map((f) => path.relative(process.cwd(), f))
+    .join(" ")} --write `;
+
+const addChanges = (filenames) =>
+  `git add ${filenames.map((f) => f).join(" ")}`;
+
 module.exports = {
-  "*.{js,jsx,ts,tsx}": [buildEslintCommand],
+  "*.{js,jsx,ts,tsx}": [buildEslintCommand, runPrettierCommand, addChanges],
 };

--- a/frontend/labs-chat/package.json
+++ b/frontend/labs-chat/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "lint:fix": "next lint --fix",
-    "prettier": "prettier --check .",
+    "prettier:check": "prettier --check .",
     "prettier:fix": "prettier . --write",
     "prepare": "cd ../.. && husky frontend/labs-chat/.husky"
   },


### PR DESCRIPTION
### PR Summary
Simplified the linting process to only affect the js, ts, tsx, jsx files you changed and staged for your commit. It then adds it to the commit automatically so you don't need to commit twice.